### PR TITLE
Removing mandatory span.caret

### DIFF
--- a/ButtonDropdown.php
+++ b/ButtonDropdown.php
@@ -108,7 +108,6 @@ class ButtonDropdown extends Widget
                 'view' => $this->getView(),
             ]);
         } else {
-            $label .= ' <span class="caret"></span>';
             $options = $this->options;
             if (!isset($options['href'])) {
                 $options['href'] = '#';


### PR DESCRIPTION
Please remove mandatory span caret or do it optional. If the programmer will need this element, he adds. Suppose I want to create a normal button without arrows. For this I need to add the hide of this span, that is, garbage in css