### PR TITLE
#5207 Icon Helper

### DIFF
--- a/BaseIcon.php
+++ b/BaseIcon.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\bootstrap;
+
+use yii\helpers\ArrayHelper;
+use yii\helpers\Html;
+
+/**
+ * BaseIcon provides concrete implementation for [[Icon]].
+ *
+ * Do not use BaseIcon. Use [[Icon]] instead.
+ *
+ * @see http://getbootstrap.com/components/#glyphicons
+ *
+ * @author Paul Klimov <klimov.paul@gmail.com>
+ * @since 2.0.4
+ */
+class BaseIcon
+{
+    /**
+     * Composes icon HTML.
+     * Icon specification can be:
+     * - string short name, which will be used to compose glyphicon HTML, for example: 'star'
+     * - string HTML content, which will be used as it is, for example: '<i class="my-icon"></i>'
+     * - array configuration for the tag, which should compose the icon, for example: `['tag' => 'i', 'class' => 'my-icon']`
+     * @param string|array $icon icon specification.
+     * @return string icon HTML.
+     */
+    public static function icon($icon)
+    {
+        if (is_array($icon)) {
+            $tag = ArrayHelper::remove($icon, 'tag', 'span');
+            return Html::tag($tag, '', $icon);
+        }
+        if (strpos($icon, '<') !== false) {
+            return $icon;
+        }
+        return Html::tag('span', '', ['class' => 'glyphicon glyphicon-' . $icon]);
+    }
+
+    /**
+     * Composes label with an icon attached.
+     * This method is useful composing the labels, which contain icons, for the bootstrap widgets.
+     * For example:
+     *
+     * ~~~php
+     * echo Button::widget([
+     *     'encodeLabel' => false, // disable widget label encoding
+     *     'label' => Icon::label('ok-sign', 'Approve'),
+     * ]);
+     * ~~~
+     *
+     * Note: while working with widget, make sure you disable its internal label encoding, so it
+     * displays icon HTML correctly.
+     *
+     * @param string|array $icon icon specification, see [[icon()]] for details.
+     * @param string $label the label text.
+     * @param array $options label composition options:
+     * - encode: boolean, optional, whether the label text should be HTML-encoded
+     * - template: string, optional, label composition template containing tokens `{icon}` and `{label}`
+     * @return string label HTML.
+     */
+    public static function label($icon, $label, $options = [])
+    {
+        $options = array_merge(
+            [
+                'encode' => true,
+                'template' => '{icon} {label}',
+            ],
+            $options
+        );
+        return strtr($options['template'], [
+            '{icon}' => static::icon($icon),
+            '{label}' => $options['encode'] ? Html::encode($label) : $label,
+        ]);
+    }
+} 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 bootstrap extension Change Log
 - Bug #5984: `yii\bootstrap\Activefield::checkbox()` caused browser to link label to the wrong input (cebe)
 - Enh #29: Added support to list-groups for Collapse class (pana1990, skullcrasher)
 - Enh #2546: Added `visible` option to `yii\bootstrap\ButtonGroup::$buttons` (samdark, lukBarros)
+- Enh #5207: Added `yii\bootstrap\Icon` helper to support the glyphicons (klimov-paul)
 - Enh #7633: Added `ActionColumn::$buttonOptions` for defining HTML options to be added to the default buttons (cebe)
 - Enh: Added `Nav::$dropDownCaret` to allow customization of the dropdown caret symbol (cebe)
 

--- a/Icon.php
+++ b/Icon.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @link http://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license http://www.yiiframework.com/license/
+ */
+
+namespace yii\bootstrap;
+
+/**
+ * Icon is a helper class, which provides support for Bootstrap Glyphicon icons rendering.
+ *
+ * @see http://getbootstrap.com/components/#glyphicons
+ *
+ * @author Paul Klimov <klimov.paul@gmail.com>
+ * @since 2.0.4
+ */
+class Icon extends BaseIcon
+{
+} 

--- a/tests/IconTest.php
+++ b/tests/IconTest.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace yiiunit\extensions\bootstrap;
+
+use yii\bootstrap\Icon;
+
+/**
+ * @group bootstrap
+ */
+class IconTest extends TestCase
+{
+    /**
+     * Data provider for [[testIcon()]]
+     * @return array test data
+     */
+    public function dataProviderIcon()
+    {
+        return [
+            [
+                'star',
+                '<span class="glyphicon glyphicon-star"></span>',
+            ],
+            [
+                '<i class="my-icon"></i>',
+                '<i class="my-icon"></i>',
+            ],
+            [
+                [
+                    'tag' => 'i',
+                    'class' => 'my-icon',
+                ],
+                '<i class="my-icon"></i>',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderIcon
+     */
+    public function testIcon($icon, $expectedHtml)
+    {
+        $this->assertEquals($expectedHtml, Icon::icon($icon));
+    }
+
+    /**
+     * Data provider for [[testLabel()]]
+     * @return array test data
+     */
+    public function dataProviderLabel()
+    {
+        return [
+            [
+                'star',
+                'test label',
+                [],
+                '<span class="glyphicon glyphicon-star"></span> test label',
+            ],
+            [
+                'star',
+                '<html-encoded>',
+                [],
+                '<span class="glyphicon glyphicon-star"></span> &lt;html-encoded&gt;',
+            ],
+            [
+                'star',
+                '<not-html-encoded>',
+                [
+                    'encode' => false
+                ],
+                '<span class="glyphicon glyphicon-star"></span> <not-html-encoded>',
+            ],
+            [
+                'star',
+                'reverse-template',
+                [
+                    'template' => '{label} {icon}'
+                ],
+                'reverse-template <span class="glyphicon glyphicon-star"></span>',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderLabel
+     * @depends testIcon
+     *
+     * @param string|array $icon
+     * @param string $label
+     * @param array $options
+     * @param string $expectedHtml
+     */
+    public function testLabel($icon, $label, $options, $expectedHtml)
+    {
+        $this->assertEquals($expectedHtml, Icon::label($icon, $label, $options));
+    }
+} 


### PR DESCRIPTION
Fix for https://github.com/yiisoft/yii2/issues/5207
Added helper 'Icon' to support the glypicons composition

Alternative to #31.
Solution is heavier to apply by end-developer, but leaves widgets intact.