### PR TITLE
use bootstrap classes for errorSummaryCssClass

### DIFF
--- a/ActiveForm.php
+++ b/ActiveForm.php
@@ -82,6 +82,10 @@ class ActiveForm extends \yii\widgets\ActiveForm
      */
     public $layout = 'default';
 
+    /**
+     * @inheritdoc
+     */
+    public $errorSummaryCssClass = 'alert alert-danger error-summary';
 
     /**
      * @inheritdoc


### PR DESCRIPTION
added `alert alert-danger` to the css class so that the error message is rendered nicely
