### PR TITLE
Fix: label in inline form not visible

### DIFF
--- a/ActiveField.php
+++ b/ActiveField.php
@@ -375,7 +375,6 @@ class ActiveField extends \yii\widgets\ActiveField
             $config['errorOptions'] = ['class' => 'help-block help-block-error ' . $cssClasses['error']];
             $config['hintOptions'] = ['class' => 'help-block ' . $cssClasses['hint']];
         } elseif ($layout === 'inline') {
-            $config['labelOptions'] = ['class' => 'sr-only'];
             $config['enableError'] = false;
         }
 


### PR DESCRIPTION
When using inline-form expected that I will see the label http://getbootstrap.com/css/#forms-inline
But if form inline, then add class "sr-only" in label.

expected (without sr-only)
![expected](https://cloud.githubusercontent.com/assets/7720715/9376621/65040992-4718-11e5-8c1c-ae22fbc4cce0.png)

actual (with sr-only)
![actual](https://cloud.githubusercontent.com/assets/7720715/9376622/65080344-4718-11e5-9e01-dcd88acfaade.png)

If needed add class "sr-only", can be added manually in ActiveForm::fieldConfig
$form = ActiveForm::begin(['layout' => 'inline', 'fieldConfig' =>  ['labelOptions' => ['class' => 'sr-only']]]);