### PR TITLE
Automatically hide parent 'yii\bootstrap\Nav' section if all subitems are hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Yii Framework 2 bootstrap extension Change Log
 - Bug #81: Fixed `yii\bootstrap\ActiveField::radioList()` and `yii\bootstrap\ActiveField::checkboxList()` ignore `itemOptions` (mikehaertl)
 - Bug #98: Fixed `yii\bootstrap\ButtonDropdown` setting `href` attribute for non `a` tags (13nightevil)
 - Enh #45: Added support for Bootstrap checkbox/radio toggle buttons (RomeroMsk, klimov-paul)
+- Enh #117: Automatically hide parent 'yii\bootstrap\Nav' section if all subitems are hidden (arogachev)
 
 2.0.5 September 23, 2015
 ------------------------

--- a/Nav.php
+++ b/Nav.php
@@ -141,7 +141,7 @@ class Nav extends Widget
     {
         $items = [];
         foreach ($this->items as $i => $item) {
-            if (isset($item['visible']) && !$item['visible']) {
+            if (!$this->isParentVisible($item)) {
                 continue;
             }
             $items[] = $this->renderItem($item);
@@ -199,6 +199,32 @@ class Nav extends Widget
         }
 
         return Html::tag('li', Html::a($label, $url, $linkOptions) . $items, $options);
+    }
+
+    /**
+     * Check if parent item is visible
+     * @param array $parentItem
+     * @return boolean
+     */
+    protected function isParentVisible($parentItem)
+    {
+        if (isset($parentItem['visible']) && !$parentItem['visible']) {
+            return false;
+        }
+
+        $items = ArrayHelper::getValue($parentItem, 'items');
+        if (empty($items)) {
+            return true;
+        }
+
+        foreach ($items as $item) {
+            $isVisible = ArrayHelper::getValue($item, 'visible');
+            if ($isVisible !== false) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/Nav.php
+++ b/Nav.php
@@ -212,8 +212,8 @@ class Nav extends Widget
             return false;
         }
 
-        $items = ArrayHelper::getValue($parentItem, 'items', []);
-        if ($items === []) {
+        $items = ArrayHelper::getValue($parentItem, 'items');
+        if (empty($items)) {
             return true;
         }
 

--- a/Nav.php
+++ b/Nav.php
@@ -212,8 +212,8 @@ class Nav extends Widget
             return false;
         }
 
-        $items = ArrayHelper::getValue($parentItem, 'items');
-        if (empty($items)) {
+        $items = ArrayHelper::getValue($parentItem, 'items', []);
+        if ($items === []) {
             return true;
         }
 

--- a/tests/NavTest.php
+++ b/tests/NavTest.php
@@ -119,4 +119,45 @@ EXPECTED;
 
         $this->assertEqualsWithoutLE($expected, $out);
     }
+
+    public function testHiddenParent()
+    {
+        Nav::$counter = 0;
+        $out = Nav::widget([
+            'items' => [
+                [
+                    'label' => 'Dropdown1',
+                    'visible' => false,
+                    'items' => [
+                        ['label' => 'Page1', 'content' => 'Page1'],
+                        ['label' => 'Page2', 'content' => 'Page2'],
+                    ],
+                ],
+                [
+                    'label' => 'Page3',
+                ],
+                [
+                    'label' => 'Dropdown2',
+                    'items' => [
+                        ['label' => 'Page4', 'content' => 'Page4', 'visible' => false],
+                        ['label' => 'Page5', 'content' => 'Page5', 'visible' => false],
+                    ],
+                ],
+                [
+                    'label' => 'Dropdown3',
+                    'items' => [
+                        ['label' => 'Page6', 'content' => 'Page6', 'visible' => true],
+                        ['label' => 'Page7', 'content' => 'Page7', 'visible' => false],
+                    ],
+                ],
+            ],
+        ]);
+
+        $expected = <<<EXPECTED
+<ul id="w0" class="nav"><li><a href="#">Page3</a></li>
+<li class="dropdown"><a class="dropdown-toggle" href="#" data-toggle="dropdown">Dropdown3 <b class="caret"></b></a><ul id="w1" class="dropdown-menu"><li class="dropdown-header">Page6</li></ul></li></ul>
+EXPECTED;
+
+        $this->assertEqualsWithoutLE($expected, $out);
+    }
 }


### PR DESCRIPTION
Closes #117
