### PR TITLE
Fix: Now content property can accept pure numerical value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yii Framework 2 bootstrap extension Change Log
 -----------------------
 
 - Bug #126: `yii\bootstrap\ToggleButtonGroup` was unable to work without model (makroxyz)
+- Bug: Fixed `yii\bootstrap\Collapse` to use pure numerical value on `content` property (meysampg)
 
 2.0.6 March 17, 2016
 --------------------

--- a/Collapse.php
+++ b/Collapse.php
@@ -144,7 +144,7 @@ class Collapse extends Widget
 
             $header = Html::tag('h4', $headerToggle, ['class' => 'panel-title']);
 
-            if (is_string($item['content']) || is_object($item['content'])) {
+            if (is_string($item['content']) || is_numeric($item['content']) || is_object($item['content'])) {
                 $content = Html::tag('div', $item['content'], ['class' => 'panel-body']) . "\n";
             } elseif (is_array($item['content'])) {
                 $content = Html::ul($item['content'], [


### PR DESCRIPTION
On late, if you have something like this on collapse:
```
echo Collapse::widget([
	'items' => [
        [
            'label' => 'Sample label',
            'content' => 1,
        ],
    ]
]);
```
`Yii` has thrown an exception that `The "content" option should be a string, array or object.`, but in some situations you need to print only numerical value on collapse. This pull request fix this bug.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes

