### PR TITLE
Tabs feature. Set HTML attributes to `tab-content`  container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 bootstrap extension Change Log
 
 - Bug #126: `yii\bootstrap\ToggleButtonGroup` was unable to work without model (makroxyz)
 - Bug #130: Fixed `yii\bootstrap\Collapse` to use pure numerical value on `content` property (meysampg)
+- Enh #131 Added `tabContentOptions` to set HTML attributes for 'tab-content' container in `Tabs` (AndrewKorpusov)
 
 2.0.6 March 17, 2016
 --------------------

--- a/Tabs.php
+++ b/Tabs.php
@@ -117,6 +117,7 @@ class Tabs extends Widget
 
     /**
      * @var array list of Html attributes for the `tab-content` container
+     * @since 2.0.7
      */
     public $tabContentOptions = [];
 
@@ -127,8 +128,7 @@ class Tabs extends Widget
     {
         parent::init();
         Html::addCssClass($this->options, ['widget' => 'nav', $this->navType]);
-        if ($this->renderTabContent)
-            Html::addCssClass($this->tabContentOptions, 'tab-content');
+        Html::addCssClass($this->tabContentOptions, 'tab-content');
     }
 
     /**

--- a/Tabs.php
+++ b/Tabs.php
@@ -115,6 +115,10 @@ class Tabs extends Widget
      */
     public $renderTabContent = true;
 
+    /**
+     * @var array list of Html attributes for the `tab-content` container
+     */
+    public $tabContentOptions = [];
 
     /**
      * Initializes the widget.
@@ -123,6 +127,8 @@ class Tabs extends Widget
     {
         parent::init();
         Html::addCssClass($this->options, ['widget' => 'nav', $this->navType]);
+        if ($this->renderTabContent)
+            Html::addCssClass($this->tabContentOptions, 'tab-content');
     }
 
     /**
@@ -203,7 +209,7 @@ class Tabs extends Widget
         }
 
         return Html::tag('ul', implode("\n", $headers), $this->options)
-        . ($this->renderTabContent ? "\n" . Html::tag('div', implode("\n", $panes), ['class' => 'tab-content']) : '');
+        . ($this->renderTabContent ? "\n" . Html::tag('div', implode("\n", $panes), $this->tabContentOptions) : '');
     }
 
     /**

--- a/tests/TabsTest.php
+++ b/tests/TabsTest.php
@@ -3,7 +3,6 @@ namespace yiiunit\extensions\bootstrap;
 
 use yii\bootstrap\Tabs;
 use yii\helpers\Html;
-use yii\helpers\VarDumper;
 
 /**
  * Tests for Tabs widget

--- a/tests/TabsTest.php
+++ b/tests/TabsTest.php
@@ -3,6 +3,7 @@ namespace yiiunit\extensions\bootstrap;
 
 use yii\bootstrap\Tabs;
 use yii\helpers\Html;
+use yii\helpers\VarDumper;
 
 /**
  * Tests for Tabs widget
@@ -125,5 +126,25 @@ class TabsTest extends TestCase
         ]);
 
         $this->assertContains('<' . $checkTag, $out);
+    }
+
+    public function testTabContentOptions()
+    {
+        $checkAttribute = "test_attribute";
+        $checkValue = "check_attribute";
+
+        $out = Tabs::widget([
+            'items' => [
+                [
+                    'label' => 'Page1', 'content'=>'Page1'
+                ]
+            ],
+            'tabContentOptions' => [
+                $checkAttribute => $checkValue
+            ]
+        ]);
+
+        $this->assertContains($checkAttribute.'=', $out);
+        $this->assertContains($checkValue, $out);
     }
 }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | no |
| New feature? | yes |
| Breaks BC? | yes |
| Tests pass? | yes |
| Fixed issues | - |
