### PR TITLE
Remove forced role=navbar from yii\bootstrap\NavBar which fixes #137

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Yii Framework 2 bootstrap extension Change Log
 - Bug #124: Fixed `yii\bootstrap\Tabs` to use `tag` configuration option for item container (arturf)
 - Enh #45: Added support for Bootstrap checkbox/radio toggle buttons (RomeroMsk, klimov-paul)
 - Enh #92: Allow overriding `data-toggle` in `yii\bootstrap\Tabs` (machour)
+- Bug #137: Remove role="navbar" from yii\bootstrap\NavBar according to new aria specification
 
 
 2.0.5 September 23, 2015

--- a/NavBar.php
+++ b/NavBar.php
@@ -100,9 +100,6 @@ class NavBar extends Widget
         } else {
             Html::addCssClass($this->options, ['widget' => 'navbar']);
         }
-        if (empty($this->options['role'])) {
-            $this->options['role'] = 'navigation';
-        }
         $options = $this->options;
         $tag = ArrayHelper::remove($options, 'tag', 'nav');
         echo Html::beginTag($tag, $options);

--- a/tests/NavBarTest.php
+++ b/tests/NavBarTest.php
@@ -12,6 +12,8 @@ class NavBarTest extends TestCase
 {
     public function testRender()
     {
+        NavBar::$counter = 0;
+
         $out = NavBar::widget([
             'brandLabel' => 'My Company',
             'brandUrl' => '/',
@@ -19,8 +21,6 @@ class NavBarTest extends TestCase
                 'class' => 'navbar-inverse navbar-static-top navbar-frontend',
             ],
         ]);
-
-        echo $out;
 
         $expected = <<<EXPECTED
 <nav id="w0" class="navbar-inverse navbar-static-top navbar-frontend navbar"><div class="container"><div class="navbar-header"><button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#w0-collapse"><span class="sr-only">Toggle navigation</span>

--- a/tests/NavBarTest.php
+++ b/tests/NavBarTest.php
@@ -1,0 +1,34 @@
+<?php
+namespace yiiunit\extensions\bootstrap;
+
+use yii\bootstrap\NavBar;
+
+/**
+ * Tests for NavBar widget
+ * 
+ * @group bootstrap
+ */
+class NavBarTest extends TestCase
+{
+    public function testRender()
+    {
+        $out = NavBar::widget([
+            'brandLabel' => 'My Company',
+            'brandUrl' => '/',
+            'options' => [
+                'class' => 'navbar-inverse navbar-static-top navbar-frontend',
+            ],
+        ]);
+
+        echo $out;
+
+        $expected = <<<EXPECTED
+<nav id="w0" class="navbar-inverse navbar-static-top navbar-frontend navbar"><div class="container"><div class="navbar-header"><button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#w0-collapse"><span class="sr-only">Toggle navigation</span>
+<span class="icon-bar"></span>
+<span class="icon-bar"></span>
+<span class="icon-bar"></span></button><a class="navbar-brand" href="/">My Company</a></div><div id="w0-collapse" class="collapse navbar-collapse"></div></div></nav>
+EXPECTED;
+
+        $this->assertEqualsWithoutLE($expected, $out);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #137

