### PR TITLE
Fix documentation url

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ in Yii applications extremely easy.
 
 For license information check the [LICENSE](LICENSE.md)-file.
 
-Documentation is at [docs/guide/README.md](docs/guide/README.md).
+Documentation for extension is at [docs/guide/README.md](https://github.com/yiisoft/yii2-bootstrap/blob/master/docs/guide/README.md).
 
 [![Latest Stable Version](https://poser.pugx.org/yiisoft/yii2-bootstrap/v/stable.png)](https://packagist.org/packages/yiisoft/yii2-bootstrap)
 [![Total Downloads](https://poser.pugx.org/yiisoft/yii2-bootstrap/downloads.png)](https://packagist.org/packages/yiisoft/yii2-bootstrap)


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Is bugfix? | yes |
| New feature? | no |
| Breaks BC? | no |
| Tests pass? | no |
| Fixed issues |  |

Broken link when read on http://www.yiiframework.com/doc-2.0/ext-bootstrap-index.html
Note: It is still confusing on how to get from guide part to api part...
