### PR TITLE
Update Dropdown.php

### DIFF
--- a/Dropdown.php
+++ b/Dropdown.php
@@ -38,7 +38,8 @@ class Dropdown extends Widget
      * @var array list of menu items in the dropdown. Each array element can be either an HTML string,
      * or an array representing a single menu with the following structure:
      *
-     * - label: string, required, the label of the item link
+     * - label: string, required, the label of the item link.
+     * - encode: boolean, optional, whether to HTML-ecnode item label.
      * - url: string|array, optional, the url of the item link. This will be processed by [[Url::to()]].
      *   If not set, the item will be treated as a menu header when the item has no sub-menu.
      * - visible: boolean, optional, whether this menu item is visible. Defaults to true.
@@ -101,11 +102,11 @@ class Dropdown extends Widget
     {
         $lines = [];
         foreach ($items as $item) {
-            if (isset($item['visible']) && !$item['visible']) {
-                continue;
-            }
             if (is_string($item)) {
                 $lines[] = $item;
+                continue;
+            }
+            if (isset($item['visible']) && !$item['visible']) {
                 continue;
             }
             if (!array_key_exists('label', $item)) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -

Two changes:
1. Documented previously undocumented 'encode' item option.
2. Moved `is_string($item)` check to occur BEFORE `$item` is handled as array. When `$item` is a string `$item['visible']` would not be an error and will return the first character of that string. Doing `!$item['visible']` on the first character of a string does not make any sense.