### PR TITLE
Fixed `yii\bootstrap\Nav` not taking explicit `active` into account when `activateItems` is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Yii Framework 2 bootstrap extension Change Log
 - Bug #137: Remove `role="navbar"` from `yii\bootstrap\NavBar` according to new aria specification (tino415)
 - Enh #113: Allow URLs instead of content for Tab Widget Dropdown items (Okeanos)
 - Bug #143: Fixed `yii\bootstrap\Nav` to use tags according to bootstrap docs (PowerGamer1)
+- Bug #162: Fixed `yii\bootstrap\Nav` not taking explicit `active` into account when `activateItems` is off (samdark)
 
 2.0.6 March 17, 2016
 --------------------

--- a/Nav.php
+++ b/Nav.php
@@ -199,7 +199,7 @@ class Nav extends Widget
             }
         }
 
-        if ($this->activateItems && $active) {
+        if ($active) {
             Html::addCssClass($options, 'active');
         }
 

--- a/tests/NavTest.php
+++ b/tests/NavTest.php
@@ -119,4 +119,33 @@ EXPECTED;
 
         $this->assertEqualsWithoutLE($expected, $out);
     }
+
+    /**
+     * @see https://github.com/yiisoft/yii2-bootstrap/issues/162
+     */
+    public function testExplicitActive()
+    {
+        Nav::$counter = 0;
+        $out = Nav::widget([
+            'activateItems' => false,
+            'items' => [
+                [
+                    'label' => 'Item1',
+                    //'url' => ['some/route1'],
+                    'active' => true,
+                ],
+                [
+                    'label' => 'Item2',
+                    //'url' => ['some/route2'],
+                ],
+            ],
+        ]);
+
+        $expected = <<<EXPECTED
+<ul id="w0" class="nav"><li class="active"><a href="#">Item1</a></li>
+<li><a href="#">Item2</a></li></ul>
+EXPECTED;
+
+        $this->assertEqualsWithoutLE($expected, $out);
+    }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes/no
| Fixed issues  | #162
