### PR TITLE
Added `renderPanes()` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Yii Framework 2 bootstrap extension Change Log
 - Enh #113: Allow URLs instead of content for Tab Widget Dropdown items (Okeanos)
 - Bug #143: Fixed `yii\bootstrap\Nav` to use tags according to bootstrap docs (PowerGamer1)
 - Bug #162: Fixed `yii\bootstrap\Nav` not taking explicit `active` into account when `activateItems` is off (samdark)
-- Enh: Added `yii\bootstrap\Tabs::renderPanes()` to allow you to overwrite the class and manipulate the content between the tabs and the content. (thiagotalma)
+- Enh #174: Added `yii\bootstrap\Tabs::renderPanes()` to allow you to overwrite the class and manipulate the content between the tabs and the content. (thiagotalma)
 
 2.0.6 March 17, 2016
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Yii Framework 2 bootstrap extension Change Log
 - Enh #113: Allow URLs instead of content for Tab Widget Dropdown items (Okeanos)
 - Bug #143: Fixed `yii\bootstrap\Nav` to use tags according to bootstrap docs (PowerGamer1)
 - Bug #162: Fixed `yii\bootstrap\Nav` not taking explicit `active` into account when `activateItems` is off (samdark)
-- Enh #174: Added `yii\bootstrap\Tabs::renderPanes()` to allow you to overwrite the class and manipulate the content between the tabs and the content. (thiagotalma)
+- Enh #174: Added `yii\bootstrap\Tabs::renderPanes()` to allow extending the class to manipulate the content between the tabs and the content (thiagotalma)
 
 2.0.6 March 17, 2016
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Yii Framework 2 bootstrap extension Change Log
 - Enh #113: Allow URLs instead of content for Tab Widget Dropdown items (Okeanos)
 - Bug #143: Fixed `yii\bootstrap\Nav` to use tags according to bootstrap docs (PowerGamer1)
 - Bug #162: Fixed `yii\bootstrap\Nav` not taking explicit `active` into account when `activateItems` is off (samdark)
+- Enh: Added `yii\bootstrap\Tabs::renderPanes()` to allow you to overwrite the class and manipulate the content between the tabs and the content. (thiagotalma)
 
 2.0.6 March 17, 2016
 --------------------

--- a/Tabs.php
+++ b/Tabs.php
@@ -213,8 +213,7 @@ class Tabs extends Widget
             $headers[] = Html::tag('li', $header, $headerOptions);
         }
 
-        return Html::tag('ul', implode("\n", $headers), $this->options)
-        . ($this->renderTabContent ? "\n" . Html::tag('div', implode("\n", $panes), ['class' => 'tab-content']) : '');
+        return Html::tag('ul', implode("\n", $headers), $this->options) . $this->renderPanes($panes);
     }
 
     /**
@@ -278,5 +277,17 @@ class Tabs extends Widget
         }
 
         return $itemActive;
+    }
+
+    /**
+     * Renders tab panes.
+     *
+     * @param array $panes
+     *
+     * @return string the rendering result.
+     */
+    public function renderPanes($panes)
+    {
+        return ($this->renderTabContent ? "\n" . Html::tag('div', implode("\n", $panes), ['class' => 'tab-content']) : '');
     }
 }

--- a/Tabs.php
+++ b/Tabs.php
@@ -283,11 +283,11 @@ class Tabs extends Widget
      * Renders tab panes.
      *
      * @param array $panes
-     *
      * @return string the rendering result.
+     * @since 2.0.7
      */
     public function renderPanes($panes)
     {
-        return ($this->renderTabContent ? "\n" . Html::tag('div', implode("\n", $panes), ['class' => 'tab-content']) : '');
+        return $this->renderTabContent ? "\n" . Html::tag('div', implode("\n", $panes), ['class' => 'tab-content']) : '';
     }
 }


### PR DESCRIPTION
Added `yii\bootstrap\Tabs::renderPanes()` to allow you to overwrite the class and manipulate the content between the tabs and the content

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes

