### PR TITLE
Bump Tether to match BS4.alpha6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "require": {
         "yiisoft/yii2": ">=2.0.6",
         "bower-asset/bootstrap": "~4.0.0@alpha",
-        "bower-asset/tether": "1.2.*"
+        "bower-asset/tether": "1.4.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Bootstrap 4.alpha6 requires tether 1.4.*.
Updating this dependancy is important as alpha6 has significant changes, mainly flexbox being the default.

| Q             | A
| ------------- | ---
| Is bugfix?    | No
| New feature?  | ? - Important for pathway to release.
| Breaks BC?    | no
| Tests pass?   | Failed. (see comments below.)
| Fixed issues  | Allows upgrade to bs 4.0.0-alpha6
