### PR TITLE
Remove forced role=form from yii\bootstrap\ActiveForm which fixes #196

### DIFF
--- a/ActiveForm.php
+++ b/ActiveForm.php
@@ -70,7 +70,7 @@ class ActiveForm extends \yii\widgets\ActiveForm
      */
     public $fieldClass = 'yii\bootstrap\ActiveField';
     /**
-     * @var array HTML attributes for the form tag. Default is `['role' => 'form']`.
+     * @var array HTML attributes for the form tag. Default is `[]`.
      */
     public $options = [];
     /**

--- a/ActiveForm.php
+++ b/ActiveForm.php
@@ -72,7 +72,7 @@ class ActiveForm extends \yii\widgets\ActiveForm
     /**
      * @var array HTML attributes for the form tag. Default is `['role' => 'form']`.
      */
-    public $options = ['role' => 'form'];
+    public $options = [];
     /**
      * @var string the form layout. Either 'default', 'horizontal' or 'inline'.
      * By choosing a layout, an appropriate default field configuration is applied. This will

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Yii Framework 2 bootstrap extension Change Log
 - Bug #143: Fixed `yii\bootstrap\Nav` to use tags according to bootstrap docs (PowerGamer1)
 - Bug #162: Fixed `yii\bootstrap\Nav` not taking explicit `active` into account when `activateItems` is off (samdark)
 - Enh #174: Added `yii\bootstrap\Tabs::renderPanes()` to allow extending the class to manipulate the content between the tabs and the content (thiagotalma)
+- Bug #196: Remove `role="form"` from `yii\bootstrap\ActiveForm` according to new aria specification (bastardijke)
 
 2.0.6 March 17, 2016
 --------------------

--- a/tests/ActiveFormTest.php
+++ b/tests/ActiveFormTest.php
@@ -1,0 +1,32 @@
+<?php
+namespace yiiunit\extensions\bootstrap;
+
+use yii\bootstrap\ActiveForm;
+
+/**
+ * Tests for ActiveForm widget
+ * 
+ * @group bootstrap
+ */
+class ActiveFormTest extends TestCase
+{
+
+    protected function setUp()
+    {
+        // dirty way to have Request object not throwing exception when running testFormNoRoleAttribute()
+        $_SERVER['REQUEST_URI'] = "index.php";
+
+        parent::setUp();
+
+    }
+
+    /**
+     * Fixes #196
+     */
+    public function testFormNoRoleAttribute()
+    {
+        $form = ActiveForm::widget();
+
+        $this->assertNotContains('role="form"', $form);
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | #196 
