### PR TITLE
fixed plugin for ButtonDropdown widget

### DIFF
--- a/ButtonDropdown.php
+++ b/ButtonDropdown.php
@@ -84,7 +84,7 @@ class ButtonDropdown extends Widget
         $options = $this->containerOptions;
         $tag = ArrayHelper::remove($options, 'tag', 'div');
 
-        $this->registerPlugin('button');
+        $this->registerPlugin('dropdown');
         return implode("\n", [
             Html::beginTag($tag, $options),
             $this->renderButton(),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Yii Framework 2 bootstrap extension Change Log
 - Bug #143: Fixed `yii\bootstrap\Nav` to use tags according to bootstrap docs (PowerGamer1)
 - Bug #162: Fixed `yii\bootstrap\Nav` not taking explicit `active` into account when `activateItems` is off (samdark)
 - Enh #174: Added `yii\bootstrap\Tabs::renderPanes()` to allow extending the class to manipulate the content between the tabs and the content (thiagotalma)
-- Bug #184: `yii\bootstrap\ButtonDropdown` widget did not use the correct JS plugin, was `button`, changed to `dropdown` (cebe,yukal)
+- Bug #184: `yii\bootstrap\ButtonDropdown` widget did not use the correct JS plugin, was `button`, changed to `dropdown` (cebe, yukal)
 - Bug #196: Remove `role="form"` from `yii\bootstrap\ActiveForm` according to new aria specification (bastardijke)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Yii Framework 2 bootstrap extension Change Log
 - Bug #143: Fixed `yii\bootstrap\Nav` to use tags according to bootstrap docs (PowerGamer1)
 - Bug #162: Fixed `yii\bootstrap\Nav` not taking explicit `active` into account when `activateItems` is off (samdark)
 - Enh #174: Added `yii\bootstrap\Tabs::renderPanes()` to allow extending the class to manipulate the content between the tabs and the content (thiagotalma)
+- Bug #184: `yii\bootstrap\ButtonDropdown` widget did not use the correct JS plugin, was `button`, changed to `dropdown` (cebe,yukal)
 - Bug #196: Remove `role="form"` from `yii\bootstrap\ActiveForm` according to new aria specification (bastardijke)
 
 


### PR DESCRIPTION


| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | not sure
| Tests pass?   | unsure what to test
| Fixed issues  | fixes #184

This fixes #184 however I do not see any change in behavior of the button dropdown when I create it like this:

```php
    <?php echo ButtonDropdown::widget([
        'label' => 'Action',
        'dropdown' => [
            'items' => [
                ['label' => 'DropdownA', 'url' => '/'],
                ['label' => 'DropdownB', 'url' => '#'],
            ],
        ],
    ]); ?>
```

anyone can explain why it worked before and why change is needed? @yukal