### PR TITLE
Allow configuration of checkbox ActiveField label class name

### DIFF
--- a/ActiveField.php
+++ b/ActiveField.php
@@ -206,7 +206,6 @@ class ActiveField extends \yii\widgets\ActiveField
             if ($this->form->layout === 'horizontal') {
                 Html::addCssClass($this->wrapperOptions, $this->horizontalCssClasses['offset']);
             }
-            $this->labelOptions['class'] = null;
         }
 
         return parent::checkbox($options, false);

--- a/tests/ActiveFieldTest.php
+++ b/tests/ActiveFieldTest.php
@@ -110,4 +110,30 @@ HTML;
 
         $this->assertContains('data-attribute="test"', $content);
     }
+
+    public function testCheckboxOptionsLabelClass()
+    {
+        $className = 'test-class';
+
+        $this->activeField->labelOptions = [
+            'class' => $className,
+        ];
+        $content = $this->activeField->checkbox()->render();
+
+        $this->assertContains("class=\"{$className}\"", $content);
+    }
+
+    public function testCheckboxLabelOptionsClass()
+    {
+        $className = 'test-class';
+
+        $content = $this->activeField->checkbox([
+                'label' => 'test-label',
+                'labelOptions' => [
+                    'class' => $className,
+                ],
+            ])->render();
+
+        $this->assertContains("class=\"{$className}\"", $content);
+    }
 }


### PR DESCRIPTION
For no apparent reason (not apparent to me, that is) the author of `ActiveField` decided, that the `class` attribute of a checkbox label should not be configurable. I beg to differ.

| Q             | A
| ------------- | ---
| Is bugfix?    | yes/no
| New feature?  | no/yes
| Breaks BC?    | possibly
| Tests pass?   | yes
| Fixed issues  | no issue opened (yet)

BC could get broken for those relying on `class` being ignored in `labelOptions` (no idea why would anyone want to do that, though).

I figured that opening an issue for discussion would take more time then just creating a PR that fixes the problem, since an existing pull request can be merged or rejected any time, while an issue would require someone to create a PR for it to be resolved anyway.