### PR TITLE
Upgrade Bootstrap to 4 beta version

### DIFF
--- a/BootstrapPluginAsset.php
+++ b/BootstrapPluginAsset.php
@@ -24,6 +24,6 @@ class BootstrapPluginAsset extends AssetBundle
     public $depends = [
         'yii\web\JqueryAsset',
         'yii\bootstrap\BootstrapAsset',
-        'yii\bootstrap\TetherAsset',
+        'yii\bootstrap\PopperAsset',
     ];
 }

--- a/PopperAsset.php
+++ b/PopperAsset.php
@@ -10,18 +10,15 @@ namespace yii\bootstrap;
 use yii\web\AssetBundle;
 
 /**
- * Asset bundle for Tether javascript files.
+ * Asset bundle for Popper javascript files.
  *
- * @author Alan Willms <alanwillms@gmail.com>
+ * @author Artur Zhdanov <zhdanovartur@gmail.com>
  * @since 2.0
  */
-class TetherAsset extends AssetBundle
+class PopperAsset extends AssetBundle
 {
-    public $sourcePath = '@bower/tether/dist';
-    public $css = [
-        'css/tether.css',
-    ];
+    public $sourcePath = '@bower/popper.js/dist';
     public $js = [
-        'js/tether.js',
+        'umd/popper.js',
     ];
 }

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     ],
     "require": {
         "yiisoft/yii2": "~2.0.6",
-        "bower-asset/bootstrap": "~4.0.0@alpha",
-        "bower-asset/tether": "1.4.*"
+        "bower-asset/bootstrap": "~4.0.0@beta",
+        "bower-asset/popper.js": "~1.12.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Replace tether to popper.js library (it's new dependency)

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  |
