### PR TITLE
Fix #286: Fix `@var` annotation for `Modal::$toggleButton`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Yii Framework 2 bootstrap extension Change Log
 
 - Enh #281: Applying Yii2 coding standards (@s1lver)
 - Enh #281: Raise min version to PHP 7.4 (@s1lver)
+- Bug #286: Fix `@var` annotation for `Modal::$toggleButton` (mspirkov)
 
 
 2.0.11 August 09, 2021

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -397,12 +397,6 @@ parameters:
 			path: src/InputWidget.php
 
 		-
-			message: '#^Strict comparison using \!\=\= between array and false will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: src/InputWidget.php
-
-		-
 			message: '#^Method yii\\bootstrap\\Modal\:\:init\(\) has no return type specified\.$#'
 			identifier: missingType.return
 			count: 1
@@ -469,12 +463,6 @@ parameters:
 			path: src/Modal.php
 
 		-
-			message: '#^Property yii\\bootstrap\\Modal\:\:\$toggleButton \(array\) does not accept default value of type false\.$#'
-			identifier: property.defaultValue
-			count: 1
-			path: src/Modal.php
-
-		-
 			message: '#^Property yii\\bootstrap\\Modal\:\:\$toggleButton type has no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
@@ -483,7 +471,7 @@ parameters:
 		-
 			message: '#^Strict comparison using \!\=\= between array and false will always evaluate to true\.$#'
 			identifier: notIdentical.alwaysTrue
-			count: 3
+			count: 1
 			path: src/Modal.php
 
 		-
@@ -495,6 +483,18 @@ parameters:
 		-
 			message: '#^Call to an undefined method yii\\console\\Request\|yii\\web\\Request\:\:getQueryParams\(\)\.$#'
 			identifier: method.notFound
+			count: 1
+			path: src/Nav.php
+
+		-
+			message: '#^Cannot access property \$controller on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 4
+			path: src/Nav.php
+
+		-
+			message: '#^Cannot access property \$request on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/Nav.php
 
@@ -559,8 +559,8 @@ parameters:
 			path: src/Nav.php
 
 		-
-			message: '#^Access to an undefined property yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\:\:\$homeUrl\.$#'
-			identifier: property.notFound
+			message: '#^Cannot access property \$homeUrl on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
 			count: 1
 			path: src/NavBar.php
 
@@ -859,19 +859,25 @@ parameters:
 			path: tests/HtmlTest.php
 
 		-
+			message: '#^Cannot access property \$controller on yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null\.$#'
+			identifier: property.nonObject
+			count: 2
+			path: tests/NavTest.php
+
+		-
 			message: '#^Method yiiunit\\extensions\\bootstrap\\NavTest\:\:mockAction\(\) has parameter \$params with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: tests/NavTest.php
 
 		-
-			message: '#^Property yii\\base\\Controller\<yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\>\:\:\$module \(yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\) does not accept yii\\base\\Module\.$#'
-			identifier: assign.propertyType
+			message: '#^Parameter \#2 \$module of class yii\\web\\Controller constructor expects yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>, yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\|null given\.$#'
+			identifier: argument.type
 			count: 1
 			path: tests/NavTest.php
 
 		-
-			message: '#^Property yii\\console\\Application\:\:\$controller \(yii\\console\\Controller\<yii\\base\\Module\>\|yii\\web\\Controller\<yii\\base\\Module\>\|null\) does not accept yii\\web\\Controller\<yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\>\.$#'
+			message: '#^Property yii\\base\\Controller\<yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\>\:\:\$module \(yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\) does not accept yii\\base\\Module\.$#'
 			identifier: assign.propertyType
 			count: 1
 			path: tests/NavTest.php
@@ -891,12 +897,6 @@ parameters:
 		-
 			message: '#^Method yiiunit\\extensions\\bootstrap\\TestCase\:\:mockWebApplication\(\) has parameter \$config with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
-			count: 1
-			path: tests/TestCase.php
-
-		-
-			message: '#^Static property yii\\BaseYii\<yii\\web\\IdentityInterface\>\:\:\$app \(yii\\console\\Application\|yii\\web\\Application\<yii\\web\\IdentityInterface\>\) does not accept null\.$#'
-			identifier: assign.propertyType
 			count: 1
 			path: tests/TestCase.php
 

--- a/src/Modal.php
+++ b/src/Modal.php
@@ -85,7 +85,7 @@ class Modal extends Widget
      */
     public $closeButton = [];
     /**
-     * @var array the options for rendering the toggle button tag.
+     * @var array|false the options for rendering the toggle button tag.
      * The toggle button is used to toggle the visibility of the modal window.
      * If this property is false, no toggle button will be rendered.
      *


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

I tested [mspirkov/yii2-phpstan-rules](https://github.com/mspirkov/yii2-phpstan-rules) and found this error:

<img width="1263" height="177" alt="image" src="https://github.com/user-attachments/assets/6893adb0-34db-44c0-a2c2-4eadb4532098" />
